### PR TITLE
allow jenkins-slave to run "mock" on Red Hat

### DIFF
--- a/cookbooks/jenkins-slave/recipes/centos6.rb
+++ b/cookbooks/jenkins-slave/recipes/centos6.rb
@@ -218,3 +218,4 @@ service "httpd" do
   action [ :disable, :stop ]
 end
 
+include_recipe "jenkins-slave::redhat-mock"

--- a/cookbooks/jenkins-slave/recipes/centos7.rb
+++ b/cookbooks/jenkins-slave/recipes/centos7.rb
@@ -90,3 +90,5 @@ execute "Sudoers and security/lmits.conf changes" do
     sed -i 's/^#\*.*soft.*core.*0/\*                soft    core            unlimited/g' /etc/security/limits.conf
   EOH
 end
+
+include_recipe "jenkins-slave::redhat-mock"

--- a/cookbooks/jenkins-slave/recipes/fedora.rb
+++ b/cookbooks/jenkins-slave/recipes/fedora.rb
@@ -180,3 +180,5 @@ end
 service "httpd" do
   action [ :disable, :stop ]
 end
+
+include_recipe "jenkins-slave::redhat-mock"

--- a/cookbooks/jenkins-slave/recipes/redhat-mock.rb
+++ b/cookbooks/jenkins-slave/recipes/redhat-mock.rb
@@ -1,0 +1,13 @@
+# On Red Hat-based systems, in order to run the "mock" command, you must be a
+# member of the "mock" group. (This is because mock has special root-like
+# powers to set up a chroot, etc.)
+
+# This recipe puts Jenkins into the mock group so that it can run the mock
+# command.
+
+group "mock" do
+  action :modify
+  members "jenkins-build"
+  append true
+end
+

--- a/cookbooks/jenkins-slave/recipes/redhat6.rb
+++ b/cookbooks/jenkins-slave/recipes/redhat6.rb
@@ -221,3 +221,4 @@ service "httpd" do
   action [ :disable, :stop ]
 end
 
+include_recipe "jenkins-slave::redhat-mock"

--- a/cookbooks/jenkins-slave/recipes/redhat7.rb
+++ b/cookbooks/jenkins-slave/recipes/redhat7.rb
@@ -176,3 +176,5 @@ end
 service "httpd" do
   action [ :disable, :stop ]
 end
+
+include_recipe "jenkins-slave::redhat-mock"


### PR DESCRIPTION
This pull request creates a new `redhat::mock` recipe, and adds it to all the Red Hat-based recipes. This will permit us to use mock to build packages on the Red Hat-based Jenkins slaves.
