### PR TITLE
fix EPEL 7 repo label

### DIFF
--- a/cookbooks/jenkins-slave/files/default/epel7.repo
+++ b/cookbooks/jenkins-slave/files/default/epel7.repo
@@ -1,5 +1,5 @@
 [epel]
-name=Extra Packages for Enterprise Linux 6 - $basearch
+name=Extra Packages for Enterprise Linux 7 - $basearch
 baseurl=http://apt-mirror.front.sepia.ceph.com/epel7/
 enabled=1
 gpgcheck=0


### PR DESCRIPTION
Fix a bad copy & paste from the EPEL 6 .repo file.
