### PR TITLE
update solo-from-scratch deployment URL

### DIFF
--- a/solo/solo-from-scratch
+++ b/solo/solo-from-scratch
@@ -3,7 +3,7 @@
 # This file is not chmod a+x on purpose, to avoid running it
 # accidentally. Automation will always run it through
 #
-# wget --no-check-certificate -q -O- https://raw.github.com/ceph/jenkins-slave-chef/master/solo/solo-from-scratch | sh
+# wget --no-check-certificate -q -O- https://raw.githubusercontent.com/ceph/jenkins-slave-chef/master/solo/solo-from-scratch | sh
 
 set -e
 


### PR DESCRIPTION
GitHub hosts raw content from a different domain now. Update our script to reflect this.
