### PR TITLE
rakefile: make foodcritic gem dependency optional

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,18 @@
 #!/usr/bin/env rake
 
-require 'foodcritic'
+begin
+  require 'foodcritic'
+rescue LoadError
+  # foodcritic task will be unavailable
+end
 
 desc 'Runs foodcritic linter'
 task :foodcritic do
+  unless defined?(FoodCritic)
+    warn 'Please install the "foodcritic" gem.'
+    exit 1
+  end
+
   files = Dir.glob('./cookbooks/**/*.rb')
 
   files.each do |file|


### PR DESCRIPTION
If the foodcritic gem is not installed, we should still be able to invoke "rake" without crashing.
